### PR TITLE
Darwin (Mac) uses the same vboxmanage syntax as linux

### DIFF
--- a/lib/virtualbox.js
+++ b/lib/virtualbox.js
@@ -2,7 +2,7 @@ var exec = require('child_process').exec,
     logging = require('./logging'),
     undefined = function(){}();
 
-var isLinux = (process.platform == 'linux');
+var isLinux = (process.platform == 'linux' || process.platform == 'darwin');
 
 function command(cmd, callback) {
   exec(cmd, function(err, stdout, stderr){


### PR DESCRIPTION
While Darwin (Mac OS X) isn't Linux, it uses the same vboxmanage executable.
