### PR TITLE
Fixed incorrect run command when using VirtualBox5

### DIFF
--- a/lib/virtualbox.js
+++ b/lib/virtualbox.js
@@ -212,7 +212,7 @@ function vmExec(options, callback) {
     var runcmd = ' execute  --image ';
 
     if (vbox_version == 5) {
-      runcmd = ' run --exe ';
+      runcmd = ' run ';
     }
 
     switch (os_type) {


### PR DESCRIPTION
Using the run command ' run --exe ' causes an error in VirtualBox5

'VBoxManage: warning: Error getting stdout handle: VERR_NOT_IMPLEMENTED'

Changing this to ' run ' solves this problem.

Tested against  VirtualBox 5.0.14 on OSX 10.11.3