### PR TITLE
use EOL constant

### DIFF
--- a/lib/virtualbox.js
+++ b/lib/virtualbox.js
@@ -186,7 +186,7 @@ function snapshotList(vmname, callback) {
     var s;
     var snapshots = [];
     var currentSnapshot;
-    var lines = (stdout || '').split('\n');
+    var lines = (stdout || '').split(require('os').EOL);
 
     lines.forEach(function(line) {
       line.replace(/^(CurrentSnapshotUUID|SnapshotName|SnapshotUUID).*\="(.*)"$/, function(l, k, v) {


### PR DESCRIPTION
snapshotList fails on windows, cause of different line endings