### PR TITLE
Added cloning functionality and changed exec mechanism

### DIFF
--- a/README.md
+++ b/README.md
@@ -237,7 +237,7 @@ In case the VM doesn't have an IDE controller you can use the storagectl command
 ```javascript
 virtualbox.storage.addCtl({
 	vm: "machine_name",
-	device_name: "IDE", //optional
+	perhiperal_name: "IDE", //optional
 	type: "ide" //optional
 }, function(){
 	console.log('Controller has been added!');
@@ -251,7 +251,7 @@ Mount an ISO file to the added controller:
 ```javascript
 virtualbox.storage.attach({
 	vm: "machine_name",
-	device_name: "IDE", //optional
+	perhiperal_name: "IDE", //optional
 	port: "0", //optional
 	device: "0", //optional
 	type: "dvddrive", //optional

--- a/README.md
+++ b/README.md
@@ -358,7 +358,7 @@ var options = {
   key: "/VirtualBox/GuestInfo/Net/0/V4/IP"
 }
 
-virtualbox.guestproperty(function guestproperty_callback(machines, error) {
+virtualbox.guestproperty.get(function guestproperty_callback(machines, error) {
   if (error) throw error;
   // Act on machines
 });
@@ -432,7 +432,7 @@ virtualbox.start("machine_name", function start_callback(error) {
 - `.poweroff({vm:"machine_name"}, callback)`
 - `.acpisleepbutton({vm:"machine_name"}, callback)`
 - `.acpipowerbutton({vm:"machine_name"}, callback)`
-- `.guestproperty({vm:"machine_name", property: "propname"}, callback)`
+- `.guestproperty.get({vm:"machine_name", property: "propname"}, callback)`
 - `.exec(){vm: "machine_name", cmd: "C:\\Program Files\\Internet Explorer\\iexplore.exe", params: "http://google.com"}, callback)`
 - `.exec(){vm: "machine_name", user:"Administrator", password: "123456", cmd: "C:\\Program Files\\Internet Explorer\\iexplore.exe", params: "http://google.com"}, callback)`
 - `.keyboardputscancode("machine_name", [scan_codes], callback)`
@@ -444,6 +444,9 @@ virtualbox.start("machine_name", function start_callback(error) {
 - `.snapshotDelete({vm:"machine_name"}, {vm:"snapshot_UUID"}, callback)`
 - `.snapshotRestore({vm:"machine_name"}, {vm:"snapshot_UUID"}, callback)`
 - `.clone({vm:"machine_name"}, {vm:"new_machine_name"}, callback)`
+- `.clone({vm:"machine_name"}, {vm:"new_machine_name"}, callback)`
+- `.storage.addCtl({vm: "machine_name", perhiperal_name: "IDE", type: "ide"}, callback)`
+- `.storage.attach({vm: "machine_name", perhiperal_name: "IDE", port: "0", device: "0", type: "dvddrive", medium: "X:\Folder\containing\the.iso"}, callback)`
 - `.extradata.get({vm:"machine_name", key:"keyname"}, callback)`
 - `.extradata.set({vm:"machine_name", key:"keyname", value:"val"}, callback)`
 

--- a/README.md
+++ b/README.md
@@ -197,6 +197,31 @@ virtualbox.snapshotRestore("machine_name", "snapshot_name", function(error) {
 });
 ```
 
+## Cloning VMs
+
+Make a full clone (duplicate virtual hard drive) of a machine:
+
+```javascript
+virtualbox.clone("source_machine_name", "new_machine_name", function(error) {
+  if (error) throw error;
+	console.log('Done fully cloning the virtual machine!');
+});
+```
+
+Make a linked clone (interdependent-differentially stored virtual hard drive) of a machine:
+
+```javascript
+virtualbox.snapshotTake("machine_name", "snapshot_name", function(error, uuid) {
+  if (error) throw error;
+	console.log('Snapshot has been taken!');
+	console.log('UUID: ', uuid);
+	virtualbox.clone("machine_name", "new_machine_name", "snapshot_name", function(error) {
+  		if (error) throw error;
+		console.log('Done making a linked clone of the virtual machine!');
+	});
+});
+```
+
 # Controlling the guest OS
 
 ## A note about security :warning:
@@ -377,6 +402,7 @@ virtualbox.start("machine_name", function start_callback(error) {
 - `.snapshotTake({vm:"machine_name"}, {vm:"snapshot_name"},  callback)`
 - `.snapshotDelete({vm:"machine_name"}, {vm:"snapshot_UUID"}, callback)`
 - `.snapshotRestore({vm:"machine_name"}, {vm:"snapshot_UUID"}, callback)`
+- `.clone({vm:"machine_name"}, {vm:"new_machine_name"}, callback)`
 - `.extradata.get({vm:"machine_name", key:"keyname"}, callback)`
 - `.extradata.set({vm:"machine_name", key:"keyname", value:"val"}, callback)`
 

--- a/README.md
+++ b/README.md
@@ -252,9 +252,9 @@ Mount an ISO file to the added controller:
 virtualbox.storage.attach({
 	vm: "machine_name",
 	device_name: "IDE", //optional
-	port: "ide", //optional
-	device: "0",
-	type: "0",
+	port: "0", //optional
+	device: "0", //optional
+	type: "dvddrive", //optional
 	medium: "X:\Folder\containing\the.iso"
 }, function(){
 	console.log('Image has been mounted!');

--- a/README.md
+++ b/README.md
@@ -14,6 +14,12 @@ A JavaScript library to interact with [VirtualBox](https://www.virtualbox.org/) 
 	- [Starting a cold machine: Two ways](#starting-a-cold-machine-two-ways)
 	- [Stopping a machine](#stopping-a-machine)
 	- [Pausing, Saving and Resuming a machine](#pausing-saving-and-resuming-a-machine)
+- [Export a Machine](#export-a-machine)
+- [Snapshot Manage](#snapshot-manage)
+- [Cloning a VM](#cloning-vms)
+- [Storage](#storage)
+	- [Manage the IDE controller](#manage-the-ide-controller)
+	- [Attach a disk image file](#attach-a-disk-image-file)
 - [Controlling the guest OS](#controlling-the-guest-os)
 	- [A note about security :warning:](#a-note-about-security)
 	- [Running programs in the guest](#running-programs-in-the-guest)
@@ -221,6 +227,41 @@ virtualbox.snapshotTake("machine_name", "snapshot_name", function(error, uuid) {
 	});
 });
 ```
+
+## Storage
+
+### Manage the IDE controller
+
+In case the VM doesn't have an IDE controller you can use the storagectl command to add one:
+
+```javascript
+virtualbox.storage.addCtl({
+	vm: "machine_name",
+	device_name: "IDE", //optional
+	type: "ide" //optional
+}, function(){
+	console.log('Controller has been added!');
+})
+```
+
+### Attach a disk image file
+
+Mount an ISO file to the added controller:
+
+```javascript
+virtualbox.storage.attach({
+	vm: "machine_name",
+	device_name: "IDE", //optional
+	port: "ide", //optional
+	device: "0",
+	type: "0",
+	medium: "X:\Folder\containing\the.iso"
+}, function(){
+	console.log('Image has been mounted!');
+})
+```
+
+The _medium_ parameter of the options object can be set to the **none** value to unmount.
 
 # Controlling the guest OS
 

--- a/lib/virtualbox.js
+++ b/lib/virtualbox.js
@@ -527,6 +527,7 @@ module.exports = {
   'snapshotRestore': snapshotRestore,
   'isRunning': isRunning,
   'extradata': extradata,
+  'clone': clone
 
   'SCAN_CODES': require('./scan-codes')
 };

--- a/lib/virtualbox.js
+++ b/lib/virtualbox.js
@@ -289,6 +289,20 @@ function snapshotRestore(vmname, uuid, callback) {
   vboxmanage(['snapshot', vmname, 'restore', uuid], callback);
 }
 
+function clone(vmname, clonevmname, /*optional*/ snapshot, callback) {
+  var cmd = ['clonevm', vmname, '--name', clonevmname, "--register"];
+  if(typeof snapshot === 'function') {
+    callback = snapshot;
+    snapshot = undefined;
+  }else{
+    cmd.push("--options");
+    cmd.push("link");
+    cmd.push("--snapshot")";
+    cmd.push(snapshot);
+  }
+  vboxmanage(cmd, callback);
+}
+
 function isRunning(vmname, callback) {
   vboxmanage(['list', 'runningvms'], function (error, stdout) {
     logging.info('Checking virtual machine "%s" is running or not', vmname);

--- a/lib/virtualbox.js
+++ b/lib/virtualbox.js
@@ -307,6 +307,27 @@ function clone(vmname, clonevmname, /*optional*/ snapshot, callback) {
   vboxmanage(cmd, callback);
 }
 
+var storage = {
+    addCtl: function (options, callback){
+      var vm = options.vm || options.name || options.vmname || options.title,
+          device_name = options.perhiperal_name || "IDE",
+          type = options.type || "ide";
+      logging.info('Adding "%s" controller named "%s" to %s', type, name,vm);
+      var cmd = ['storagectl', vm, '--name', device_name, "--add", type];
+      vboxmanage(cmd, callback);
+    },
+    attach: function (options, callback){
+      var vm = options.vm || options.name || options.vmname || options.title,
+          device_name = options.perhiperal_name,
+          port = options.port || "0",
+          device = options.device || "0",
+          type = options.type || "dvddrive";
+      logging.info('Adding "%s" controller named "%s" to %s', type, name,vm);
+      var cmd = ['storageattach', vm, '--storagectl', device_name, "--port", port, "--device", device, "--type", type, "--medium", "medium"];
+      vboxmanage(cmd, callback);
+    }
+}
+
 function isRunning(vmname, callback) {
   vboxmanage(['list', 'runningvms'], function (error, stdout) {
     logging.info('Checking virtual machine "%s" is running or not', vmname);
@@ -528,6 +549,7 @@ module.exports = {
   'isRunning': isRunning,
   'extradata': extradata,
   'clone': clone,
+  'storage': storage,
 
   'SCAN_CODES': require('./scan-codes')
 };

--- a/lib/virtualbox.js
+++ b/lib/virtualbox.js
@@ -2,7 +2,7 @@
 
 // @todo use a promise library instead of so many callbacks
 
-const execFile = require('child_process').execFile,
+const execFile = require('child_process').exec,
   host_platform = process.platform,
   logging = require('./logging'),
    known_OS_types = {

--- a/lib/virtualbox.js
+++ b/lib/virtualbox.js
@@ -318,7 +318,7 @@ var storage = {
     },
     attach: function (options, callback){
       var vm = options.vm || options.name || options.vmname || options.title,
-          device_name = options.perhiperal_name,
+          device_name = options.perhiperal_name || "IDE",
           port = options.port || "0",
           device = options.device || "0",
           type = options.type || "dvddrive";

--- a/lib/virtualbox.js
+++ b/lib/virtualbox.js
@@ -312,7 +312,7 @@ var storage = {
       var vm = options.vm || options.name || options.vmname || options.title,
           device_name = options.perhiperal_name || "IDE",
           type = options.type || "ide";
-      logging.info('Adding "%s" controller named "%s" to %s', type, name,vm);
+      logging.info('Adding "%s" controller named "%s" to %s', type, device_name,vm);
       var cmd = ['storagectl', vm, '--name', device_name, "--add", type];
       vboxmanage(cmd, callback);
     },
@@ -321,9 +321,10 @@ var storage = {
           device_name = options.perhiperal_name || "IDE",
           port = options.port || "0",
           device = options.device || "0",
-          type = options.type || "dvddrive";
-      logging.info('Adding "%s" controller named "%s" to %s', type, name,vm);
-      var cmd = ['storageattach', vm, '--storagectl', device_name, "--port", port, "--device", device, "--type", type, "--medium", "medium"];
+          type = options.type || "dvddrive",
+          medium = options.medium;
+      logging.info('Mounting "%s" to controller named "%s" on %s', medium, device_name,vm);
+      var cmd = ['storageattach', vm, '--storagectl', device_name, "--port", port, "--device", device, "--type", type, "--medium", medium];
       vboxmanage(cmd, callback);
     }
 }

--- a/lib/virtualbox.js
+++ b/lib/virtualbox.js
@@ -290,6 +290,7 @@ function snapshotRestore(vmname, uuid, callback) {
 }
 
 function clone(vmname, clonevmname, /*optional*/ snapshot, callback) {
+  logging.info('Cloning machine "%s" to "%s"', vmname, clonevmname);
   var cmd = ['clonevm', vmname, '--name', clonevmname, "--register"];
   if(typeof snapshot === 'function') {
     callback = snapshot;

--- a/lib/virtualbox.js
+++ b/lib/virtualbox.js
@@ -527,7 +527,7 @@ module.exports = {
   'snapshotRestore': snapshotRestore,
   'isRunning': isRunning,
   'extradata': extradata,
-  'clone': clone
+  'clone': clone,
 
   'SCAN_CODES': require('./scan-codes')
 };

--- a/lib/virtualbox.js
+++ b/lib/virtualbox.js
@@ -14,8 +14,8 @@ const exec = require('child_process').exec,
 let vBoxManageBinary,
   vbox_version;
  
-function execFile(executable, arguments, callback){
-  exec(executable + arguments.join(" "), callback)
+function execFile(binary, args, func){
+  exec(binary + args.join(" "), callback)
 }
 
 // Host operating system

--- a/lib/virtualbox.js
+++ b/lib/virtualbox.js
@@ -2,7 +2,7 @@
 
 // @todo use a promise library instead of so many callbacks
 
-const execFile = require('child_process').exec,
+const exec = require('child_process').exec,
   host_platform = process.platform,
   logging = require('./logging'),
    known_OS_types = {
@@ -14,6 +14,9 @@ const execFile = require('child_process').exec,
 let vBoxManageBinary,
   vbox_version;
  
+function execFile(executable, arguments, callback){
+  exec(executable + arguments.join(" "), callback)
+}
 
 // Host operating system
 if (/^win/.test(host_platform)) {

--- a/lib/virtualbox.js
+++ b/lib/virtualbox.js
@@ -15,7 +15,7 @@ let vBoxManageBinary,
   vbox_version;
  
 function execFile(binary, args, func){
-  exec(binary + args.join(" "), callback)
+  exec(binary + args.join(" "), func)
 }
 
 // Host operating system

--- a/lib/virtualbox.js
+++ b/lib/virtualbox.js
@@ -298,7 +298,7 @@ function clone(vmname, clonevmname, /*optional*/ snapshot, callback) {
   }else{
     cmd.push("--options");
     cmd.push("link");
-    cmd.push("--snapshot")";
+    cmd.push("--snapshot");
     cmd.push(snapshot);
   }
   vboxmanage(cmd, callback);


### PR DESCRIPTION
- Added cloning functionality and examples (for full clone and linked clone) to the Readme
- Added a wrapper function execFile instead of the native execFile, based on plain exec. This is because at least on my system (Ubuntu 20.04 LTS), exec could not find vboxmanage although it was in the path

Changes are tested on Ubuntu Linux node/8.9.3, node/10.19.0, node/12.16.2